### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/hammbakie/7f1b6f30-e91d-4472-919f-899e7e1640eb/ecd35994-3a40-4d00-8605-14c0e515d831/_apis/work/boardbadge/034cb0b9-8c46-4c1e-8892-01c0b67dc589)](https://dev.azure.com/hammbakie/7f1b6f30-e91d-4472-919f-899e7e1640eb/_boards/board/t/ecd35994-3a40-4d00-8605-14c0e515d831/Microsoft.RequirementCategory)
 # hammbak.github.io


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.